### PR TITLE
Bypass M1 Mac crash until a proper integration can be introduced

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,28 @@
-const binding = require('node-gyp-build')(__dirname)
-const enums = require('./src/enums');
+const enums = require('./src/enums')
 const converters = require('./src/converters')
+let binding
+
+try {
+  binding = require('node-gyp-build')(__dirname)
+  binding.CorsairGetLastError()
+} catch {
+  binding = {
+    CorsairPerformProtocolHandshake: function () {
+      return null
+    },
+    CorsairGetLastError: function () {
+      return enums.CorsairError.CE_ProtocolHandshakeMissing
+    },
+    CorsairGetDeviceCount: function () {
+      return 0
+    }
+  }
+}
 
 const sdk = {
   ...enums,
   ...converters,
-  ...binding,
-};
+  ...binding
+}
 
-module.exports = sdk;
+module.exports = sdk


### PR DESCRIPTION
Code from Intrueder to bypass the crash that is happening for M1 Macs